### PR TITLE
Add tomato size option

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ const approximations = [
   { name: "the width of %d credit card", size: 0.083},
   { name: "the height of %d credit card", size: 0.053},
   { name: "the size of %d paper clip", size: 0.025},
-  
+  { name: "the size of %d large tomato", size: 0.10, plural: "es" },
 ];
 
 function getRandom(list) {


### PR DESCRIPTION
In all good US converters there must be a way to provide an answer in Tomatoes - this is afterall standard form when converting miles to feet.
I resisted the tempation to special case 528m.

The size here comes from Wikipedia (sorry) - "The size of "the tomato varies according to the cultivar, with a range of 1–10 cm (1⁄2–4 in) in width."